### PR TITLE
fix: resolve ESLint errors in match notification feature

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/frontend/app/__tests__/match-notification.test.tsx
+++ b/frontend/app/__tests__/match-notification.test.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'next/navigation';
 // Mock next/navigation
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
 }));
 
 // Mock fetch globally

--- a/frontend/app/room/[code]/page.tsx
+++ b/frontend/app/room/[code]/page.tsx
@@ -299,7 +299,7 @@ export default function RoomPage() {
               <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/20">
                 <Heart className="w-8 h-8 text-primary fill-primary" />
               </div>
-              <h2 className="text-2xl font-bold">It's a match!</h2>
+              <h2 className="text-2xl font-bold">It&apos;s a match!</h2>
               <p className="text-sm text-muted-foreground">
                 You and your friends liked
               </p>


### PR DESCRIPTION
## Summary

- Add `.eslintrc.json` with `next/core-web-vitals` config to fix missing ESLint setup
- Fix unescaped apostrophe in match modal (`It's` → `It&apos;s`)
- Add `useRouter` mock in match notification tests to prevent test failures

## Test plan

- [ ] `just check` passes in frontend
- [ ] Match modal still displays correctly with the apostrophe fix
- [ ] Match notification tests pass without `useRouter` mock error