### PR TITLE
feat: watch now deep links ✨

### DIFF
--- a/backend/alembic/versions/c7f1a2b3d4e5_add_watch_link_to_movie_availability.py
+++ b/backend/alembic/versions/c7f1a2b3d4e5_add_watch_link_to_movie_availability.py
@@ -1,0 +1,29 @@
+"""Add watch link to movie availability
+
+Revision ID: c7f1a2b3d4e5
+Revises: b2c3d4e5f6a1
+Create Date: 2026-07-01
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7f1a2b3d4e5'
+down_revision: Union[str, None] = 'b2c3d4e5f6a1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'movie_availabilities',
+        sa.Column('link', sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('movie_availabilities', 'link')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -93,6 +93,8 @@ class MovieAvailability(Base):
     movie_id = Column(Integer, ForeignKey("movies.id"), nullable=False)
     region = Column(String(2), nullable=False)  # ISO 3166-1 alpha-2 country code
     provider_id = Column(Integer, nullable=False)  # TMDB watch provider ID
+    # TMDB region-level "where to watch" page URL (same for every provider in the region)
+    link = Column(String(500), nullable=True)
 
     movie = relationship("Movie", back_populates="availabilities")
 

--- a/backend/app/routers/movies.py
+++ b/backend/app/routers/movies.py
@@ -168,8 +168,30 @@ def _extract_available_providers(
         return []
 
 
-def _record_movie_availability(db: Session, movie: Movie, region: str, provider_id: int) -> None:
-    """Record that a movie is available for a specific region/provider."""
+def _extract_watch_link(db: Session, tmdb_id: int, region: str) -> str | None:
+    """Get TMDB's region-level "where to watch" link for a movie, if any.
+
+    TMDB's watch/providers response includes a region-level ``link`` (a page listing
+    where to watch the movie in that region). Returns None when the region is missing,
+    has no link, or the details fetch fails.
+    """
+    try:
+        details = get_movie_details(db, tmdb_id)
+        watch_providers = details.get("watch/providers", {}).get("results", {})
+        region_data = watch_providers.get(region, {})
+        return region_data.get("link")
+    except Exception:
+        return None
+
+
+def _record_movie_availability(
+    db: Session, movie: Movie, region: str, provider_id: int, link: str | None = None
+) -> None:
+    """Record that a movie is available for a specific region/provider.
+
+    ``link`` is the TMDB region-level watch link; it is stored on creation and refreshed
+    on re-sync when TMDB changes it.
+    """
     existing = (
         db.query(MovieAvailability)
         .filter(
@@ -184,8 +206,13 @@ def _record_movie_availability(db: Session, movie: Movie, region: str, provider_
             movie_id=movie.id,
             region=region,
             provider_id=provider_id,
+            link=link,
         )
         db.add(availability)
+        db.commit()
+    elif link is not None and existing.link != link:
+        # Re-sync: TMDB re-indexed the region and the watch link changed.
+        existing.link = link
         db.commit()
 
 
@@ -223,6 +250,27 @@ def _get_movie_providers(
     return providers
 
 
+def _get_movie_watch_link(
+    db: Session, movie: Movie, region: str, room_provider_ids: list[int]
+) -> str | None:
+    """Get the TMDB region-level watch link for a movie, filtered by room providers.
+
+    The link is region-level, so it is identical across a movie's availability rows for a
+    given region; we return the first non-null one among the room's selected providers.
+    """
+    row = (
+        db.query(MovieAvailability.link)
+        .filter(
+            MovieAvailability.movie_id == movie.id,
+            MovieAvailability.region == region,
+            MovieAvailability.provider_id.in_(room_provider_ids),
+            MovieAvailability.link.isnot(None),
+        )
+        .first()
+    )
+    return row[0] if row else None
+
+
 def _movie_to_response(db: Session, movie: Movie, region: str, provider_ids: list[int]) -> dict:
     """Convert a Movie model to a MovieResponse dict with provider info."""
     providers = _get_movie_providers(db, movie, region, provider_ids)
@@ -238,6 +286,7 @@ def _movie_to_response(db: Session, movie: Movie, region: str, provider_ids: lis
         "rating": movie.rating if movie.rating else None,
         "trailer_key": movie.trailer_key,
         "available_providers": providers,
+        "watch_link": _get_movie_watch_link(db, movie, region, provider_ids),
     }
 
 
@@ -290,16 +339,18 @@ def _ensure_movies_in_pool(db: Session, room: Room, count: int = MIN_MOVIES_IN_P
                     actual_providers = _extract_available_providers(
                         db, int(tmdb_movie["id"]), region, provider_ids
                     )
+                    watch_link = _extract_watch_link(db, int(tmdb_movie["id"]), region)
                     for provider_id in actual_providers or [provider_ids[0]]:
-                        _record_movie_availability(db, existing, region, provider_id)
+                        _record_movie_availability(db, existing, region, provider_id, watch_link)
                 else:
                     # Create new movie and record only actual providers
                     movie = _tmdb_to_movie(db, tmdb_movie)
                     actual_providers = _extract_available_providers(
                         db, int(tmdb_movie["id"]), region, provider_ids
                     )
+                    watch_link = _extract_watch_link(db, int(tmdb_movie["id"]), region)
                     for provider_id in actual_providers or [provider_ids[0]]:
-                        _record_movie_availability(db, movie, region, provider_id)
+                        _record_movie_availability(db, movie, region, provider_id, watch_link)
                     fetched_count += 1
 
                 if fetched_count >= needed:

--- a/backend/app/routers/votes.py
+++ b/backend/app/routers/votes.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models import Movie, Participant, Room, Vote
-from ..schemas import MatchResponse, VoteCreate, VoteResponse
+from ..routers.movies import _movie_to_response
+from ..schemas import MatchResponse, MovieResponse, VoteCreate, VoteResponse
 
 router = APIRouter()
 
@@ -70,6 +71,10 @@ def get_matches(code: str, db: Session = Depends(get_db)):
     if len(participant_ids) < 2:
         return []
 
+    # Room region/providers drive provider badges and the watch link on matched movies.
+    region: str = str(room.region)
+    provider_ids: list[int] = room.provider_ids if room.provider_ids else [8]  # type: ignore
+
     # Get all movies voted liked by each participant
     matches = []
     movies = db.query(Movie).all()
@@ -85,9 +90,10 @@ def get_matches(code: str, db: Session = Depends(get_db)):
 
         # Check if all participants liked this movie
         if set(participant_ids).issubset(set(voter_ids)):
+            movie_data = _movie_to_response(db, movie, region, provider_ids)
             matches.append(
                 MatchResponse(
-                    movie=movie,
+                    movie=MovieResponse(**movie_data),
                     participants=[p.name for p in participants],  # type: ignore
                 )
             )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -63,6 +63,7 @@ class MovieResponse(BaseModel):
     rating: Optional[float] = None  # TMDB vote_average
     trailer_key: Optional[str] = None  # YouTube trailer key
     available_providers: List[ProviderInfo] = []  # Providers where movie is available
+    watch_link: Optional[str] = None  # TMDB region-level "where to watch" page URL
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_watch_link.py
+++ b/backend/tests/test_watch_link.py
@@ -1,0 +1,225 @@
+"""Tests for persisting and exposing the TMDB region-level "watch" link.
+
+Feature 00028 (Watch Now Deep Links): TMDB's watch/providers response includes a
+region-level ``link`` (a "where to watch" page for the movie + region). We persist
+it on MovieAvailability and expose it as ``watch_link`` so the frontend can offer a
+one-tap "Where to watch" CTA on a match. Graceful null when no link exists.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import Base, engine
+from app.main import app
+from app.models import MovieAvailability
+
+
+@pytest.fixture
+def client():
+    """Create a test client with a fresh database."""
+    Base.metadata.create_all(bind=engine)
+    with TestClient(app) as c:
+        yield c
+    Base.metadata.drop_all(bind=engine)
+
+
+# A stable link per (tmdb_id, region) used across the fake responses below.
+def _link_for(tmdb_id: int, region: str = "US") -> str:
+    return f"https://www.themoviedb.org/movie/{tmdb_id}/watch?locale={region}"
+
+
+def _fake_discover(db, region="US", provider_ids=None, page=1):
+    """Fake TMDB discover response with 2 movies (1 with providers, 1 without)."""
+    return {
+        "results": [
+            {
+                "id": 2001,
+                "title": "Linked Movie",
+                "overview": "A movie streaming on Netflix with a watch link",
+                "release_date": "2024-01-01",
+                "poster_path": "/poster1.jpg",
+                "genre_ids": [28],
+                "vote_average": 7.5,
+            },
+            {
+                "id": 2002,
+                "title": "No Provider Movie",
+                "overview": "A movie with no flatrate providers and no link",
+                "release_date": "2024-02-01",
+                "poster_path": "/poster2.jpg",
+                "genre_ids": [12],
+                "vote_average": 6.0,
+            },
+        ],
+        "total_pages": 1,
+    }
+
+
+def _fake_movie_details(db, tmdb_id):
+    """Fake TMDB details with a region-level ``link`` for movie 2001 only."""
+    region_blocks = {
+        2001: {
+            "US": {
+                "link": _link_for(2001, "US"),
+                "flatrate": [{"provider_id": 8, "provider_name": "Netflix"}],
+            },
+        },
+        # 2002: no US entry at all -> no providers, no link
+        2002: {},
+    }
+    return {
+        "id": tmdb_id,
+        "genres": [{"id": 28, "name": "Action"}],
+        "videos": {"results": []},
+        "backdrop_path": None,
+        "vote_average": 7.0,
+        "watch/providers": {"results": region_blocks.get(tmdb_id, {})},
+    }
+
+
+class TestExtractWatchLink:
+    """The helper reads the region-level link and is graceful on absence."""
+
+    @patch("app.routers.movies.get_movie_details")
+    def test_returns_region_link_when_present(self, mock_details, client):
+        from app.database import SessionLocal
+        from app.routers.movies import _extract_watch_link
+
+        mock_details.side_effect = _fake_movie_details
+        db = SessionLocal()
+        try:
+            assert _extract_watch_link(db, 2001, "US") == _link_for(2001, "US")
+        finally:
+            db.close()
+
+    @patch("app.routers.movies.get_movie_details")
+    def test_returns_none_when_absent(self, mock_details, client):
+        from app.database import SessionLocal
+        from app.routers.movies import _extract_watch_link
+
+        mock_details.side_effect = _fake_movie_details
+        db = SessionLocal()
+        try:
+            # No US block for 2002, and unknown region for 2001
+            assert _extract_watch_link(db, 2002, "US") is None
+            assert _extract_watch_link(db, 2001, "ZZ") is None
+        finally:
+            db.close()
+
+
+class TestMoviesEndpointWatchLink:
+    """/api/v1/movies exposes watch_link when present, null otherwise."""
+
+    @patch("app.routers.movies.get_movie_details")
+    @patch("app.routers.movies.discover_movies")
+    @patch("app.routers.movies.TMDB_API_KEY", "fake-key")
+    def test_watch_link_present_and_null(self, mock_discover, mock_details, client):
+        mock_discover.side_effect = _fake_discover
+        mock_details.side_effect = _fake_movie_details
+
+        room_resp = client.post(
+            "/api/v1/rooms",
+            json={"region": "US", "provider_ids": [8]},
+        )
+        room_code = room_resp.json()["code"]
+        client.post(f"/api/v1/rooms/{room_code}/join", json={"name": "Alice"})
+
+        movies = client.get(f"/api/v1/movies?code={room_code}").json()["movies"]
+        by_title = {m["title"]: m for m in movies}
+
+        assert by_title["Linked Movie"]["watch_link"] == _link_for(2001, "US")
+        # No-provider movie is only seeded via fallback provider, so it has no TMDB link.
+        assert by_title["No Provider Movie"]["watch_link"] is None
+
+    @patch("app.routers.movies.get_movie_details")
+    @patch("app.routers.movies.discover_movies")
+    @patch("app.routers.movies.TMDB_API_KEY", "fake-key")
+    def test_resync_updates_changed_link(self, mock_discover, mock_details, client):
+        mock_discover.side_effect = _fake_discover
+        mock_details.side_effect = _fake_movie_details
+
+        room_resp = client.post(
+            "/api/v1/rooms",
+            json={"region": "US", "provider_ids": [8]},
+        )
+        room_code = room_resp.json()["code"]
+        client.post(f"/api/v1/rooms/{room_code}/join", json={"name": "Alice"})
+        client.get(f"/api/v1/movies?code={room_code}")
+
+        # TMDB re-indexes: the link for 2001 changes.
+        new_link = "https://www.themoviedb.org/movie/2001/watch?locale=US&v=2"
+
+        def _changed_details(db, tmdb_id):
+            data = _fake_movie_details(db, tmdb_id)
+            if tmdb_id == 2001:
+                data["watch/providers"]["results"]["US"]["link"] = new_link
+            return data
+
+        mock_details.side_effect = _changed_details
+        # Force a re-fetch which re-records availability for existing movies.
+        client.get(f"/api/v1/movies?code={room_code}&refresh=true")
+
+        from app.database import SessionLocal
+        from app.models import Movie
+
+        db = SessionLocal()
+        try:
+            movie = db.query(Movie).filter(Movie.tmdb_id == 2001).first()
+            rows = (
+                db.query(MovieAvailability)
+                .filter(
+                    MovieAvailability.movie_id == movie.id,
+                    MovieAvailability.provider_id == 8,
+                )
+                .all()
+            )
+            assert any(r.link == new_link for r in rows)
+        finally:
+            db.close()
+
+
+class TestMatchesWatchLink:
+    """/api/v1/votes/matches includes watch_link and available_providers."""
+
+    @patch("app.routers.movies.get_movie_details")
+    @patch("app.routers.movies.discover_movies")
+    @patch("app.routers.movies.TMDB_API_KEY", "fake-key")
+    def test_match_exposes_watch_link_and_providers(self, mock_discover, mock_details, client):
+        mock_discover.side_effect = _fake_discover
+        mock_details.side_effect = _fake_movie_details
+
+        room_resp = client.post(
+            "/api/v1/rooms",
+            json={"region": "US", "provider_ids": [8]},
+        )
+        room_code = room_resp.json()["code"]
+
+        # Two participants both like the linked movie.
+        client.post(
+            f"/api/v1/rooms/{room_code}/join",
+            json={"name": "Alice"},
+            cookies={"session_id": "alice-session"},
+        )
+        client.post(
+            f"/api/v1/rooms/{room_code}/join",
+            json={"name": "Bob"},
+            cookies={"session_id": "bob-session"},
+        )
+
+        movies = client.get(f"/api/v1/movies?code={room_code}").json()["movies"]
+        linked = next(m for m in movies if m["title"] == "Linked Movie")
+
+        for session in ("alice-session", "bob-session"):
+            client.post(
+                f"/api/v1/votes?code={room_code}",
+                json={"movie_id": linked["id"], "liked": True},
+                cookies={"session_id": session},
+            )
+
+        matches = client.get(f"/api/v1/votes/matches?code={room_code}").json()
+        assert len(matches) == 1
+        match_movie = matches[0]["movie"]
+        assert match_movie["watch_link"] == _link_for(2001, "US")
+        assert [p["id"] for p in match_movie["available_providers"]] == [8]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -103,10 +103,11 @@ flowchart TB
         end
 
         subgraph Models ["SQLAlchemy Models"]
-            M1["Room<br/>id, code, is_active"]
+            M1["Room<br/>id, code, is_active, region, provider_ids"]
             M2["Participant<br/>id, room_id, name, session_id"]
             M3["Movie<br/>id, title, year, genre, description"]
             M4["Vote<br/>id, room_id, participant_id, movie_id, liked"]
+            M5["MovieAvailability<br/>id, movie_id, region, provider_id, link"]
         end
 
         DB[("PostgreSQL Database")]
@@ -115,18 +116,20 @@ flowchart TB
     R1 --> M1
     R1 --> M2
     R2 --> M3
+    R2 --> M5
     R3 --> M4
     M1 --> DB
     M2 --> DB
     M3 --> DB
     M4 --> DB
+    M5 --> DB
 
     classDef router fill:#e67e22,stroke:#d35400,color:#fff,stroke-width:2px
     classDef model fill:#3498db,stroke:#2980b9,color:#fff,stroke-width:2px
     classDef db fill:#27ae60,stroke:#1e8449,color:#fff,stroke-width:2px
 
     class R1,R2,R3 router
-    class M1,M2,M3,M4 model
+    class M1,M2,M3,M4,M5 model
     class DB db
 ```
 

--- a/docs/backlog/in-progress/00028-watch-now-deep-links.md
+++ b/docs/backlog/in-progress/00028-watch-now-deep-links.md
@@ -26,24 +26,31 @@ A matched movie can be opened in one tap from the match screen, using the TMDB r
 
 ### Phase 1 — Backend: persist the TMDB region link (Red → Green → Refactor)
 Test list:
-- [ ] `get_movie_details` exposes the region-level `link` from `watch/providers.results.<region>.link`
-- [ ] `MovieAvailability` gains a nullable `link` column; Alembic migration applies cleanly
-- [ ] `_record_movie_availability` stores `link` per (movie, region) when present
-- [ ] Re-sync updates `link` if TMDB changed it
-- [ ] Movies with no providers / unknown region store null `link` (no crash)
-- [ ] `/api/v1/movies` and the matches response include `watch_link` when present, `null` otherwise
+- [x] `_extract_watch_link` exposes the region-level `link` from `watch/providers.results.<region>.link`
+- [x] `MovieAvailability` gains a nullable `link` column; Alembic migration applies cleanly
+- [x] `_record_movie_availability` stores `link` per (movie, region) when present
+- [x] Re-sync updates `link` if TMDB changed it
+- [x] Movies with no providers / unknown region store null `link` (no crash)
+- [x] `/api/v1/movies` and the matches response include `watch_link` when present, `null` otherwise
+
+Implemented in `backend/tests/test_watch_link.py` (5 tests). The `get_matches` refactor to
+`_movie_to_response` also fixed a latent bug: matched movies now carry `available_providers`
+(previously always empty in the matches response).
 
 ### Phase 2 — Frontend: match modal "Where to watch" CTA (Red → Green → Refactor)
 Test list:
-- [ ] Match modal renders a primary "Where to watch" CTA when `watch_link` is present
-- [ ] CTA opens `watch_link` in a new tab (`target="_blank"`, `rel="noopener noreferrer"`)
-- [ ] No CTA rendered when `watch_link` is null (graceful fallback, modal still usable)
-- [ ] CTA is the most prominent action (above "Continue swiping")
-- [ ] `ProviderBadges` remain visible alongside the CTA
-- [ ] Finished screen's match list also offers the CTA per matched movie
+- [x] Match modal renders a primary "Where to watch" CTA when `watch_link` is present
+- [x] CTA opens `watch_link` in a new tab (`target="_blank"`, `rel="noopener noreferrer"`)
+- [x] No CTA rendered when `watch_link` is null (graceful fallback, modal still usable)
+- [x] CTA is the most prominent action (above "Continue")
+- [x] `ProviderBadges` remain visible alongside the CTA
+- [x] Finished screen's match list also offers the CTA per matched movie
 
-### Phase 3 — Completion signal (validating, optional in this increment)
-Test list:
+Implemented in `frontend/app/room/[code]/__tests__/watch-link-cta.test.tsx`.
+
+### Phase 3 — Completion signal — DEFERRED (out of scope for this increment)
+Marked "optional in this increment"; deferred by decision to keep this increment focused and
+shippable. Will be a separate backlog item.
 - [ ] `POST /api/v1/votes/matches/{movie_id}/watched` records a tap event (no auth needed, session-scoped)
 - [ ] Event only recorded once per (participant, movie)
 - [ ] New metric surfaced: match → watch tap rate (instrument only, do not optimize)

--- a/docs/product/value-proposition.md
+++ b/docs/product/value-proposition.md
@@ -31,4 +31,9 @@ CineMatch turns movie selection into a collaborative game:
 
 - Time from room creation to match: target < 5 minutes
 - Completion rate: % of rooms that find a match
+- Watch-through: % of matches where a user taps "Where to watch" (match → watching)
 - Return rate: % of users who create multiple rooms
+
+> Watch-through closes the loop on the "Stop scrolling, start watching" promise: a match now
+> links straight to TMDB's "where to watch" page via the region-level link persisted on
+> `MovieAvailability`. Direct per-provider deep links (Netflix/Prime) remain a future increment.

--- a/frontend/app/room/[code]/__tests__/watch-link-cta.test.tsx
+++ b/frontend/app/room/[code]/__tests__/watch-link-cta.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { useParams } from "next/navigation";
+
+// Feature 00028 — Watch Now Deep Links: the match modal should offer a one-tap
+// "Where to watch" CTA opening the TMDB region link, with graceful fallback when null.
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn(),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const WATCH_LINK = "https://www.themoviedb.org/movie/27205/watch?locale=US";
+
+function makeMovie(overrides = {}) {
+  return {
+    id: 1,
+    title: "Inception",
+    year: 2010,
+    genre: "Sci-Fi",
+    description: "A thief who steals corporate secrets...",
+    poster_url: "https://example.com/poster.jpg",
+    available_providers: [{ id: 8, name: "Netflix", logo_url: "" }],
+    watch_link: WATCH_LINK,
+    ...overrides,
+  };
+}
+
+function mockRoomWithMatch(movie: { id: number; title: string }) {
+  const match = { movie, participants: ["Alice", "Bob"] };
+  // A second movie keeps the user off the "finished" screen so the match MODAL renders.
+  const filler = { ...movie, id: 999, title: "Filler Movie" };
+  const room = { code: "TEST", region: "US", provider_ids: [8] };
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes("/api/v1/movies?code=TEST")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ movies: [movie, filler], room }),
+      });
+    }
+    if (url.includes("/api/v1/votes/matches?code=TEST")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([match]) });
+    }
+    if (url.includes("/api/v1/votes?code=TEST")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 1, liked: true }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("Watch Now CTA on match", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useParams as jest.Mock).mockReturnValue({ code: "TEST" });
+  });
+
+  it("renders a 'Where to watch' CTA linking to the TMDB watch link in a new tab", async () => {
+    mockRoomWithMatch(makeMovie());
+    const { default: RoomPage } = await import("../page");
+    render(<RoomPage />);
+
+    await waitFor(() => expect(screen.getByText("Inception")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Like"));
+
+    await waitFor(() => {
+      expect(screen.getByText("It's a match!")).toBeInTheDocument();
+    });
+
+    const cta = screen.getByRole("link", { name: /where to watch/i });
+    expect(cta).toHaveAttribute("href", WATCH_LINK);
+    expect(cta).toHaveAttribute("target", "_blank");
+    expect(cta).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not render the CTA when watch_link is null (graceful fallback)", async () => {
+    mockRoomWithMatch(makeMovie({ watch_link: null }));
+    const { default: RoomPage } = await import("../page");
+    render(<RoomPage />);
+
+    await waitFor(() => expect(screen.getByText("Inception")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Like"));
+
+    await waitFor(() => {
+      expect(screen.getByText("It's a match!")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("link", { name: /where to watch/i })).not.toBeInTheDocument();
+    // Modal remains usable: the Continue action is still present.
+    expect(screen.getByText("Continue")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/room/[code]/page.tsx
+++ b/frontend/app/room/[code]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
-import { Check, Copy, Heart, X, Info, Star, Play, RefreshCw, Share2 } from "lucide-react";
+import { Check, Copy, Heart, X, Info, Star, Play, RefreshCw, Share2, ExternalLink } from "lucide-react";
 import ProviderBadges from "../../components/ProviderBadges";
 
 interface Provider {
@@ -22,6 +22,7 @@ interface Movie {
   rating?: number; // Stored as integer (e.g., 87 for 8.7)
   trailer_key?: string;
   available_providers: Provider[];
+  watch_link?: string | null; // TMDB region-level "where to watch" page URL
 }
 
 interface RoomInfo {
@@ -259,12 +260,29 @@ export default function RoomPage() {
               {matches.map((match, idx) => (
                 <div
                   key={idx}
-                  className="p-4 rounded-xl border border-input bg-card"
+                  className="p-4 rounded-xl border border-input bg-card space-y-3"
                 >
-                  <h3 className="font-medium">{match.movie.title}</h3>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {match.movie.year} • {match.movie.genre}
-                  </p>
+                  <div>
+                    <h3 className="font-medium">{match.movie.title}</h3>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {match.movie.year} • {match.movie.genre}
+                    </p>
+                  </div>
+                  {match.movie.available_providers &&
+                    match.movie.available_providers.length > 0 && (
+                      <ProviderBadges providers={match.movie.available_providers} />
+                    )}
+                  {match.movie.watch_link && (
+                    <a
+                      href={match.movie.watch_link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                      Where to watch
+                    </a>
+                  )}
                 </div>
               ))}
             </div>
@@ -497,19 +515,42 @@ export default function RoomPage() {
               </p>
             </div>
 
-            <div className="p-4 rounded-xl border border-input bg-background">
-              <h3 className="font-semibold">{showMatch.movie.title}</h3>
-              <p className="text-sm text-muted-foreground mt-1">
-                {showMatch.movie.year} • {showMatch.movie.genre}
-              </p>
+            <div className="p-4 rounded-xl border border-input bg-background space-y-3">
+              <div>
+                <h3 className="font-semibold">{showMatch.movie.title}</h3>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {showMatch.movie.year} • {showMatch.movie.genre}
+                </p>
+              </div>
+              {showMatch.movie.available_providers &&
+                showMatch.movie.available_providers.length > 0 && (
+                  <ProviderBadges providers={showMatch.movie.available_providers} />
+                )}
             </div>
 
-            <button
-              onClick={() => setShowMatch(null)}
-              className="w-full h-12 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
-            >
-              Continue
-            </button>
+            <div className="space-y-2">
+              {showMatch.movie.watch_link && (
+                <a
+                  href={showMatch.movie.watch_link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full h-12 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  Where to watch
+                </a>
+              )}
+              <button
+                onClick={() => setShowMatch(null)}
+                className={`w-full h-12 rounded-lg text-sm font-semibold hover:opacity-90 transition-opacity ${
+                  showMatch.movie.watch_link
+                    ? "bg-secondary text-secondary-foreground"
+                    : "bg-primary text-primary-foreground"
+                }`}
+              >
+                Continue
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Watch Now Deep Links (00028)

Closes the match → watch loop, delivering on the tagline **"Stop scrolling, start watching."**
The match modal no longer dead-ends at *Continue*: a matched movie can now be opened in one tap.

### What changed

**Backend — persist & expose the TMDB region link (Phase 1)**
- `MovieAvailability` gains a nullable `link` column (+ Alembic migration `c7f1a2b3d4e5`).
- The TMDB `watch/providers` region-level `link` was already fetched by `get_movie_details`
  and discarded. `_extract_watch_link` now reads it, `_record_movie_availability` stores and
  refreshes it on re-sync, and `_get_movie_watch_link` surfaces it as `watch_link` on
  `MovieResponse`.
- `votes.get_matches` now builds movies via `_movie_to_response`, so matched movies carry
  `watch_link` **and** `available_providers`. The latter fixes a latent bug: the matches
  response previously always returned empty providers.

**Frontend — "Where to watch" CTA (Phase 2)**
- Match modal and the finished-screen match list render a primary **Where to watch** CTA
  (`<a target="_blank" rel="noopener noreferrer">`) opening the TMDB link, shown above
  *Continue*, with `ProviderBadges` alongside.
- Graceful fallback: no CTA when `watch_link` is null; the modal stays usable.

### Scope note
TMDB provides a **region-level** link (a "where to watch" page), not per-provider deep links
(no `netflix.com/title/...`). Direct provider deep links (JustWatch) are an explicit future
increment. **Phase 3** (completion-signal endpoint + tap-rate metric) is deferred to keep this
increment focused and shippable.

### Testing
- `backend/tests/test_watch_link.py` — 5 tests (extract link, `/movies` present/null, re-sync
  update, no-provider null, matches `watch_link` + providers). Full backend suite: **53 passed**.
- `frontend/app/room/[code]/__tests__/watch-link-cta.test.tsx` — CTA present with correct
  `href`/`target`/`rel`; no CTA when null.
- Migration verified up/down on SQLite; backend lint/format/typecheck clean (`app/` scope).

### Docs
- `docs/architecture/overview.md`: `MovieAvailability` (with `link`) added to the model diagram.
- `docs/product/value-proposition.md`: new watch-through completion metric.

### Remaining before merge
- [ ] Verify preview deployment, capture UI screenshots (scenarios 1–3), `/backlog done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
