### PR TITLE
ci: pin pnpm to 9.15.9 to fix Node 20 incompatibility 🔧

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: "latest"
+          # Pinned: pnpm@10 requires Node >=22.13, but the workflow runs Node 20
+          version: "9.15.9"
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Enable pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Enable pnpm (pinned: pnpm@10 requires Node >=22.13, but we run Node 20)
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 COPY pnpm-lock.yaml package.json ./
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
## Fix broken frontend CI (pnpm/Node incompatibility)

### Problem
`pnpm@latest` now resolves to **pnpm v10**, which requires **Node >= 22.13** and imports
`node:sqlite`. The repo pins **Node 20** everywhere, so `pnpm install --frozen-lockfile`
crashes in both the frontend Docker build (`build-frontend`) and the `check` job:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
##[error]warn: This version of pnpm requires at least Node.js v22.13
```

This is unrelated to any feature work — the last green CI run on `main` was 2026-04-22, and
`pnpm@latest` has since bumped its Node requirement. It breaks **all** frontend CI repo-wide.

### Fix
Pin pnpm to **9.15.9** (last 9.x, matches `pnpm-lock.yaml` `lockfileVersion: 9.0`) at both
install sites:
- `frontend/Dockerfile` — `corepack prepare pnpm@9.15.9`
- `.github/workflows/ci-cd.yml` — `pnpm/action-setup` `version: "9.15.9"`

Minimal, lowest-risk unblock. Bumping to Node 22 (to keep pnpm 10) is a larger, separate change.

### Note
This PR should merge **before** #74 (watch-now-deep-links), which is blocked by the same
CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
